### PR TITLE
Rely on the IpConnection id instead of the IP

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -79,14 +79,14 @@ watchFile(logFile, () => {
             pendingIP = "";
         }
         if (newLines[i].includes("AddClientConnection: Added client connection")) {
-            let matchResult = newLines[i].match(/(?:[0-9]{1,3}\.){3}[0-9]{1,3}/gm);
+            let matchResult = newLines[i].match(/(?:IpConnection_)[0-9]*/gm);
             if (matchResult) {
                 pendingIP = matchResult[0];
             }
         }
         if (newLines[i].includes("UNetConnection::Close")) {
             let disconnectIP = "";
-            let matchResult = newLines[i].match(/(?:[0-9]{1,3}\.){3}[0-9]{1,3}/gm);
+            let matchResult = newLines[i].match(/(?:IpConnection_)[0-9]*/gm);
             if (matchResult) {
                 disconnectIP = matchResult[0];
             }


### PR DESCRIPTION
More generic solution, because IP addresses formats are not always reliable (and available)

In my case, the IP was never matched resulting in instant deconnection notification after login.
This fixed it.